### PR TITLE
Fix Yaz0 header: MemoryAlignment in big-endian

### DIFF
--- a/src/AuroraLib.Compression/Algorithms/YAZ0.cs
+++ b/src/AuroraLib.Compression/Algorithms/YAZ0.cs
@@ -86,7 +86,7 @@ namespace AuroraLib.Compression.Algorithms
         {
             destination.Write(Identifier.AsSpan());
             destination.Write(source.Length, FormatByteOrder);
-            destination.Write(MemoryAlignment);
+            destination.Write(MemoryAlignment, FormatByteOrder);
             destination.Write(0);
             CompressHeaderless(source, destination, LookAhead, level);
         }


### PR DESCRIPTION
Super small fix for the Yaz0 format's `MemoryAlignment` field.

Even when the Yaz0 header is in big-endian mode, the `MemoryAlignment` field is written as little-endian. This causes parsing issues when reading the written Yaz0 file due to an invalid `MemoryAlignment`.