### PR TITLE
Add MIME type detection to CLI tool

### DIFF
--- a/src/AuroraLib.Compression.CLI/AuroraLib.Compression.CLI.csproj
+++ b/src/AuroraLib.Compression.CLI/AuroraLib.Compression.CLI.csproj
@@ -5,6 +5,8 @@
     <TargetFrameworks>net8.0;net6.0;net472</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Version>1.0.1.0</Version>
+    <AssemblyVersion>$(Version)</AssemblyVersion>
     <AssemblyName>auracomp</AssemblyName>
     <Title>AuroraLib.Compression.CLI</Title>
     <RootNamespace>AuroraLib.Compression.CLI</RootNamespace>


### PR DESCRIPTION
fix #16
Adds a mode to determine the file format, as discussed in #16 .

### Example
`auracomp -mime -in "C:\Users\Venomalia\Desktop\Test.txt.gz"`
**Output**
```
Trying to recognize format of 'C:\Users\Venomalia\Desktop\Test.txt.gz'.
Detected format: gzip
MIME: application/gzip
```